### PR TITLE
ci: enable Zig global and local artifact caching in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,17 @@ jobs:
         with:
           version: 0.15.0
 
+      - name: Cache Zig Build Artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            .zig-cache
+            ~/.cache/zig
+            C:\Users\runneradmin\AppData\Local\zig
+          key: ${{ runner.os }}-zig-${{ hashFiles('build.zig', 'src/**/*.zig') }}
+          restore-keys: |
+            ${{ runner.os }}-zig-
+
       - name: Run Test Suite
         run: zig build test
 


### PR DESCRIPTION
Closes #13.

### Summary
- Integrated ctions/cache@v4 targeting .zig-cache and platform global caches (~/.cache/zig and Windows Local AppData).
- Reduces multi-platform CI build latency on incremental commits.