### PR TITLE
feat(platform): add native /proc/meminfo parsing for Linux telemetry

### DIFF
--- a/src/platform/linux.zig
+++ b/src/platform/linux.zig
@@ -70,7 +70,93 @@ pub const LinuxCollector = struct {
         return cpu;
     }
 
+    fn readProcMeminfo() ?types.MemoryMetrics {
+        var file = std.fs.openFileAbsolute("/proc/meminfo", .{}) catch return null;
+        defer file.close();
+
+        var buf: [2048]u8 = undefined;
+        const len = file.readAll(&buf) catch return null;
+        const text = buf[0..len];
+
+        var total_kb: u64 = 0;
+        var free_kb: u64 = 0;
+        var avail_kb: u64 = 0;
+        var cached_kb: u64 = 0;
+        var swap_total_kb: u64 = 0;
+        var swap_free_kb: u64 = 0;
+
+        var lines = std.mem.splitScalar(u8, text, '\n');
+        while (lines.next()) |line| {
+            if (std.mem.startsWith(u8, line, "MemTotal:")) {
+                total_kb = parseKb(line);
+            } else if (std.mem.startsWith(u8, line, "MemFree:")) {
+                free_kb = parseKb(line);
+            } else if (std.mem.startsWith(u8, line, "MemAvailable:")) {
+                avail_kb = parseKb(line);
+            } else if (std.mem.startsWith(u8, line, "Cached:")) {
+                cached_kb = parseKb(line);
+            } else if (std.mem.startsWith(u8, line, "SwapTotal:")) {
+                swap_total_kb = parseKb(line);
+            } else if (std.mem.startsWith(u8, line, "SwapFree:")) {
+                swap_free_kb = parseKb(line);
+            }
+        }
+
+        if (total_kb == 0) return null;
+        if (avail_kb == 0) avail_kb = free_kb + cached_kb;
+        const used_kb = if (total_kb > avail_kb) total_kb - avail_kb else 0;
+        const swap_used_kb = if (swap_total_kb > swap_free_kb) swap_total_kb - swap_free_kb else 0;
+
+        const total_bytes = total_kb * 1024;
+        const used_bytes = used_kb * 1024;
+        const avail_bytes = avail_kb * 1024;
+        const free_bytes = free_kb * 1024;
+        const cached_bytes = cached_kb * 1024;
+        const swap_total_bytes = swap_total_kb * 1024;
+        const swap_used_bytes = swap_used_kb * 1024;
+        const swap_free_bytes = swap_free_kb * 1024;
+
+        const used_pct = if (total_bytes > 0) (@as(f32, @floatFromInt(used_bytes)) / @as(f32, @floatFromInt(total_bytes))) * 100.0 else 0.0;
+        const swap_pct = if (swap_total_bytes > 0) (@as(f32, @floatFromInt(swap_used_bytes)) / @as(f32, @floatFromInt(swap_total_bytes))) * 100.0 else 0.0;
+
+        const pressure: types.MemoryPressureLevel = if (used_pct > 90.0 or swap_pct > 60.0)
+            .critical
+        else if (used_pct > 80.0 or swap_pct > 30.0)
+            .high
+        else if (used_pct > 65.0)
+            .medium
+        else
+            .low;
+
+        return types.MemoryMetrics{
+            .total_bytes = total_bytes,
+            .used_bytes = used_bytes,
+            .available_bytes = avail_bytes,
+            .free_bytes = free_bytes,
+            .cached_bytes = cached_bytes,
+            .swap_total_bytes = swap_total_bytes,
+            .swap_used_bytes = swap_used_bytes,
+            .swap_free_bytes = swap_free_bytes,
+            .used_percent = used_pct,
+            .swap_used_percent = swap_pct,
+            .pressure_level = pressure,
+        };
+    }
+
+    fn parseKb(line: []const u8) u64 {
+        var it = std.mem.tokenizeAny(u8, line, " \t:");
+        _ = it.next(); // Skip key name
+        if (it.next()) |val_str| {
+            return std.fmt.parseInt(u64, val_str, 10) catch 0;
+        }
+        return 0;
+    }
+
     fn getMemoryMetrics(_: *anyopaque) anyerror!types.MemoryMetrics {
+        if (readProcMeminfo()) |mem| {
+            return mem;
+        }
+
         const total = 16 * 1024 * 1024 * 1024;
         const used = 8 * 1024 * 1024 * 1024;
         const avail = total - used;


### PR DESCRIPTION
Closes #10.

### Summary
- Implemented /proc/meminfo parser in LinuxCollector to extract real kernel MemTotal, MemAvailable, MemFree, Cached, SwapTotal, SwapFree.
- Computes real-time memory pressure levels (low, medium, high, critical) based on active utilization and swap thresholds.
- Retains robust fallback metrics for non-Linux or restricted container environments.