### PR TITLE
feat(ui): implement modern Cyberpunk Box UI primitives and interactive Stress Test config HUD

### DIFF
--- a/src/ui/app.zig
+++ b/src/ui/app.zig
@@ -185,7 +185,7 @@ pub const App = struct {
                     self.stress_result = self.stress_tracker.final_result;
                 }
                 const res_ptr: ?*const speedtest_mod.StressTestResult = if (self.stress_result) |*r| r else null;
-                widgets.renderStressTestModal(&self.buffer, &self.stress_tracker, res_ptr, self.frame_count, &self.theme, self.plain_mode);
+                widgets.renderStressTestModal(&self.buffer, &self.stress_tracker, res_ptr, self.frame_count, &self.theme, self.plain_mode, self.stress_duration_secs, self.stress_streams);
             } else if (self.show_help) {
                 widgets.renderHelpModal(&self.buffer, &self.theme, self.plain_mode);
             }
@@ -313,41 +313,28 @@ pub const App = struct {
 
                 if (self.show_stress_modal) {
                     switch (key) {
-                        .escape, .enter => self.show_stress_modal = false,
+                        .escape => self.show_stress_modal = false,
+                        .enter => {
+                            if (!self.stress_tracker.is_running and !self.stress_tracker.has_result) {
+                                self.triggerStressTest(self.stress_duration_secs, self.stress_streams);
+                            } else {
+                                self.show_stress_modal = false;
+                            }
+                        },
                         .char => |c| switch (c) {
-                            'r', 'R' => self.triggerStressTest(self.stress_duration_secs, self.stress_streams),
-                            '1' => {
-                                self.stress_duration_secs = 10;
-                                self.triggerStressTest(10, self.stress_streams);
+                            'r', 'R' => {
+                                if (self.stress_tracker.has_result or self.stress_tracker.is_running) {
+                                    self.triggerStressTest(self.stress_duration_secs, self.stress_streams);
+                                }
                             },
-                            '2' => {
-                                self.stress_duration_secs = 30;
-                                self.triggerStressTest(30, self.stress_streams);
-                            },
-                            '3' => {
-                                self.stress_duration_secs = 60;
-                                self.triggerStressTest(60, self.stress_streams);
-                            },
-                            '4' => {
-                                self.stress_duration_secs = 300;
-                                self.triggerStressTest(300, self.stress_streams);
-                            },
-                            '5' => {
-                                self.stress_duration_secs = 900;
-                                self.triggerStressTest(900, self.stress_streams);
-                            },
-                            '6' => {
-                                self.stress_duration_secs = 3600;
-                                self.triggerStressTest(3600, self.stress_streams);
-                            },
-                            '+', '=' => {
-                                self.stress_streams = @min(32, self.stress_streams + 2);
-                                self.setStatus("Streams increased");
-                            },
-                            '-', '_' => {
-                                self.stress_streams = @max(1, self.stress_streams - 2);
-                                self.setStatus("Streams decreased");
-                            },
+                            '1' => self.stress_duration_secs = 10,
+                            '2' => self.stress_duration_secs = 30,
+                            '3' => self.stress_duration_secs = 60,
+                            '4' => self.stress_duration_secs = 300,
+                            '5' => self.stress_duration_secs = 900,
+                            '6' => self.stress_duration_secs = 3600,
+                            '+', '=' => self.stress_streams = @min(32, self.stress_streams + 2),
+                            '-', '_' => self.stress_streams = @max(1, self.stress_streams - 2),
                             'q' => self.show_stress_modal = false,
                             else => {},
                         },

--- a/src/ui/buffer.zig
+++ b/src/ui/buffer.zig
@@ -204,12 +204,12 @@ pub const ScreenBuffer = struct {
         const right = x + w - 1;
         const bottom = y + h - 1;
 
-        const tl = if (plain) "+" else "╔";
-        const tr = if (plain) "+" else "╗";
-        const bl = if (plain) "+" else "╚";
-        const br = if (plain) "+" else "╝";
-        const horiz = if (plain) "-" else "═";
-        const vert = if (plain) "|" else "║";
+        const tl = if (plain) "+" else "╭";
+        const tr = if (plain) "+" else "╮";
+        const bl = if (plain) "+" else "╰";
+        const br = if (plain) "+" else "╯";
+        const horiz = if (plain) "-" else "─";
+        const vert = if (plain) "|" else "│";
 
         self.setCell(x, y, tl, border_color, bg_color, false);
         self.setCell(right, y, tr, border_color, bg_color, false);
@@ -260,17 +260,34 @@ pub const ScreenBuffer = struct {
         bg_color: Color,
         plain: bool,
     ) void {
+        self.drawCyberBox(x, y, w, h, title, border_color, title_color, bg_color, plain);
+    }
+
+    /// Next-Gen Cyberpunk Panel Frame
+    pub fn drawCyberBox(
+        self: *ScreenBuffer,
+        x: u16,
+        y: u16,
+        w: u16,
+        h: u16,
+        title: ?[]const u8,
+        border_color: Color,
+        title_color: Color,
+        bg_color: Color,
+        plain: bool,
+    ) void {
         if (w < 2 or h < 2) return;
         const right = x + w - 1;
         const bottom = y + h - 1;
 
-        const tl = if (plain) "+" else "╔";
-        const tr = if (plain) "+" else "╗";
-        const bl = if (plain) "+" else "╚";
-        const br = if (plain) "+" else "╝";
-        const horiz_top = if (plain) "=" else "═";
-        const horiz_bot = if (plain) "-" else "─";
-        const vert = if (plain) "|" else "║";
+        const tl = if (plain) "+" else "▛";
+        const tr = if (plain) "+" else "▜";
+        const bl = if (plain) "+" else "▙";
+        const br = if (plain) "+" else "▟";
+        const horiz_top = if (plain) "-" else "▀";
+        const horiz_bot = if (plain) "-" else "▄";
+        const vert = if (plain) "|" else "▌";
+        const vert_r = if (plain) "|" else "▐";
 
         self.setCell(x, y, tl, border_color, bg_color, false);
         self.setCell(right, y, tr, border_color, bg_color, false);
@@ -286,23 +303,27 @@ pub const ScreenBuffer = struct {
         var cy = y + 1;
         while (cy < bottom) : (cy += 1) {
             self.setCell(x, cy, vert, border_color, bg_color, false);
-            self.setCell(right, cy, vert, border_color, bg_color, false);
+            self.setCell(right, cy, vert_r, border_color, bg_color, false);
         }
 
         if (title) |t| {
-            if (t.len > 0 and w > 6) {
+            if (t.len > 0 and w > 10) {
                 const title_display_len = utf8DisplayLen(t);
                 const inner_w = @as(usize, w - 2);
                 const title_x = if (title_display_len + 4 < inner_w)
                     x + @as(u16, @intCast((inner_w - title_display_len - 2) / 2)) + 1
                 else
-                    x + 2;
-                self.writeString(title_x - 1, y, " ", border_color, bg_color, false);
-                self.writeString(title_x, y, t, title_color, bg_color, true);
-                self.writeString(title_x + @as(u16, @intCast(title_display_len)), y, " ", border_color, bg_color, false);
+                    x + 4;
+                
+                self.writeString(title_x - 3, y, "◥", border_color, bg_color, false);
+                self.writeString(title_x - 2, y, " ", border_color, title_color, false); // inverted background
+                self.writeString(title_x - 1, y, t, bg_color, title_color, true); // glowing text
+                self.writeString(title_x - 1 + @as(u16, @intCast(title_display_len)), y, " ", border_color, title_color, false);
+                self.writeString(title_x - 1 + @as(u16, @intCast(title_display_len)) + 1, y, "◤", border_color, bg_color, false);
             }
         }
     }
+
 
     /// Differential flush: only writes cells that changed since last frame
     pub fn flush(self: *ScreenBuffer, writer: anytype) !void {

--- a/src/ui/widgets.zig
+++ b/src/ui/widgets.zig
@@ -1401,6 +1401,8 @@ pub fn renderStressTestModal(
     frame_count: u64,
     theme: *const Theme,
     plain: bool,
+    config_duration: u32,
+    config_streams: u32,
 ) void {
     const w = buf.width;
     const h = buf.height;
@@ -1411,7 +1413,29 @@ pub fn renderStressTestModal(
     const modal_y = (h -| modal_h) / 2;
 
     buf.fillRect(modal_x, modal_y, modal_w, modal_h, theme.bg);
-    buf.drawAccentBox(modal_x, modal_y, modal_w, modal_h, " ⚡ MULTI-STREAM NETWORK SATURATION & STRESS ENGINE ⚡ ", theme.warning, theme.warning, theme.bg, plain);
+    buf.drawCyberBox(modal_x, modal_y, modal_w, modal_h, " ⚡ MULTI-STREAM NETWORK SATURATION & STRESS ENGINE ⚡ ", theme.warning, theme.warning, theme.bg, plain);
+
+    if (!tracker.is_running and !tracker.has_result) {
+        // --- PRE-RUN CONFIGURATION HUD ---
+        buf.writeString(modal_x + 3, modal_y + 2, "◈ PRE-LAUNCH SATURATION CONFIGURATION", theme.header, theme.bg, true);
+        
+        var dur_buf: [64]u8 = undefined;
+        const dur_str = std.fmt.bufPrint(&dur_buf, "Target Duration: {d} seconds", .{config_duration}) catch "";
+        buf.writeString(modal_x + 3, modal_y + 4, dur_str, theme.warning, theme.bg, true);
+        buf.writeString(modal_x + 3, modal_y + 5, "Shortcuts: [1] 10s  [2] 30s  [3] 1m  [4] 5m  [5] 15m  [6] 1h", theme.fg, theme.bg, false);
+
+        var str_buf: [64]u8 = undefined;
+        const str_str = std.fmt.bufPrint(&str_buf, "Concurrent Socket Streams: {d}", .{config_streams}) catch "";
+        buf.writeString(modal_x + 3, modal_y + 7, str_str, theme.accent, theme.bg, true);
+        buf.writeString(modal_x + 3, modal_y + 8, "Shortcuts: [+] Increase  [-] Decrease", theme.fg, theme.bg, false);
+
+        graphs.renderSeparator(buf, modal_x + 2, modal_y + 10, modal_w - 4, theme.border, theme.bg, plain);
+        buf.writeString(modal_x + 3, modal_y + 12, "WARNING: Prolonged stress tests will heavily saturate local", theme.critical, theme.bg, true);
+        buf.writeString(modal_x + 3, modal_y + 13, "network links and may impact other users/applications.", theme.critical, theme.bg, true);
+
+        buf.writeString(modal_x + 3, modal_y + 15, "[Enter] IGNITE STRESS ENGINE  |  [Esc] Abort & Close", theme.success, theme.bg, true);
+        return;
+    }
 
     if (tracker.is_running) {
         // --- LIVE ANIMATED STRESS RUNNER HUD ---


### PR DESCRIPTION
### Summary
- **Modern CyberBox Aesthetic**: Rewrote the core TUI rendering primitives in uffer.zig to use solid block characters (\▛\, \▜\, \▀\, \▌\) and inverted glowing title banners (\◥ [ TITLE ] ◤\) for a truly next-gen cyberpunk look.
- **Sleeker Secondary Boxes**: Upgraded all standard double-lined \╔═╗\ boxes to modern smooth rounded corners \╭─╮\.
- **Interactive Pre-Launch Stress Test HUD**: Network Stress Test no longer blindly starts upon pressing \S\. It now opens an Interactive Configuration HUD, allowing the user to select precise durations (from 10 seconds to 1 hour) using keys \[1]\ through \[6]\, and configure concurrent socket streams with \+\ and \-\ before hitting \[Enter]\ to ignite the engine.